### PR TITLE
connections_forward hash vector combination 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "velox_graph"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "velox_graph"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "VeloxGraph is an extremely fast, efficient, low-level, in-memory, minimal graph database (wow, that is a mouth full). It is not revolutionary in its design but has a few key features that make it vital to the development of a new type of neural network architecture that I am working on, and THAT is what I consider revolutionary."
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ fn main() {
     let node_id1 = graph.node_create(43);
 
     // INFO: Create connection from node0 to node1.
-    graph.nodes_connection_create(node_id0, node_id1, 5.24).unwrap();
+    graph.nodes_connection_set(node_id0, node_id1, 5.24).unwrap();
 
     // INFO: Get a mutable reference to that node.
     let node0 = graph.node_get(node_id0).unwrap();
 
     println!("node0 data: {:?}", node0.data);
-    println!("node0 connections: {:?}", node0.connections_forward_get());
+    println!("node0 connections: {:?}", &node0.connections_forward_get_all().data_vec);
 }
 ```
 
@@ -92,33 +92,33 @@ fn main() {
 
     // INFO: Create connections some connections between nodes.
     graph
-        .nodes_connection_create(node_id0, node_id1, ConnData { a: 243, b: 54.5 })
+        .nodes_connection_set(node_id0, node_id1, ConnData { a: 243, b: 54.5 })
         .unwrap();
     graph
-        .nodes_connection_create(node_id0, node_id2, ConnData { a: 63, b: 9.413 })
+        .nodes_connection_set(node_id0, node_id2, ConnData { a: 63, b: 9.413 })
         .unwrap();
     graph
-        .nodes_connection_create(node_id1, node_id2, ConnData { a: 2834, b: 5.24 })
+        .nodes_connection_set(node_id1, node_id2, ConnData { a: 2834, b: 5.24 })
         .unwrap();
     graph
-        .nodes_connection_create(node_id2, node_id0, ConnData { a: 7, b: 463.62 })
+        .nodes_connection_set(node_id2, node_id0, ConnData { a: 7, b: 463.62 })
         .unwrap();
 
     // INFO: Loop through each connection that this node connects forward to (forward connections). You can NOT edit the connections.
     let node = graph.node_get(node_id0).unwrap();
-    for connection in node.connections_forward_get().values() {
+    for connection in &node.connections_forward_get_all().data_vec {
         println!("forward_connection: {:?}", connection);
     }
 
     // INFO: You can also see the what nodes the TO this node (backward connections). You can NOT edit the connections.
     let node2 = graph.node_get(node_id2).unwrap();
-    for connection in node2.connections_backward_get() {
+    for connection in node2.connections_backward_get_all() {
         println!("backward_connection: {:?}", connection);
     }
 
     // INFO: Delete node connections.
-    graph.nodes_connection_delete(node_id0, node_id1).unwrap();
-    graph.nodes_connection_delete(node_id0, node_id2).unwrap();
+    graph.nodes_connection_remove(node_id0, node_id1).unwrap();
+    graph.nodes_connection_remove(node_id0, node_id2).unwrap();
 
     // INFO: Delete nodes. Their connections are automatically deleted as well.
     graph.node_delete(0).unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,63 +47,79 @@ fn test_basic_functions() {
     assert_eq!(node_id3, 2);
     let node_id4 = graph.node_create(SomeData { x: 2, y: 51 });
     assert_eq!(node_id4, 3);
+    let node_id4 = graph.node_create(SomeData { x: 35, y: 208 });
+    assert_eq!(node_id4, 4);
 
-    assert_eq!(graph.num_entries, 4);
-    assert_eq!(graph.nodes_vector.len(), 4);
+    assert_eq!(graph.num_entries, 5);
+    assert_eq!(graph.nodes_vector.len(), 5);
     assert_eq!(graph.empty_slots.len(), 0);
 
     let node = graph.node_get(node_id).unwrap();
-    let forwards = node.connections_forward_get();
+    let forwards = node.connections_forward_get_all();
     // println!("forwards: {:?}", forwards);
-    assert_eq!(forwards.len(), 0);
+    assert_eq!(forwards.data_vec.len(), 0);
 
-    graph.nodes_connection_create(node_id, 2, 53245).unwrap();
-    graph.nodes_connection_create(node_id, 3, 24323).unwrap();
+    graph.nodes_connection_set(node_id, 2, 53245).unwrap();
+    graph.nodes_connection_set(node_id, 3, 24323).unwrap();
 
     let node = graph.node_get(node_id).unwrap();
-    let forwards = node.connections_forward_get();
-    // println!("forwards: {:?}", forwards);
-    assert_eq!(forwards.len(), 2);
-    assert_eq!(forwards.get(&2).unwrap().node_id, 2);
-    assert_eq!(forwards.get(&2).unwrap().data, 53245);
-    assert_eq!(forwards.get(&3).unwrap().node_id, 3);
-    assert_eq!(forwards.get(&3).unwrap().data, 24323);
+    let forwards = node.connections_forward_get_all();
+    assert_eq!(forwards.data_vec.len(), 2);
+    let conn_forward2 = forwards.get(2).unwrap();
+    assert_eq!(conn_forward2.node_id, 2);
+    assert_eq!(conn_forward2.data, 53245);
+    let conn_forward3 = forwards.get(3).unwrap();
+    assert_eq!(conn_forward3.node_id, 3);
+    assert_eq!(conn_forward3.data, 24323);
 
-    // for connection in node.connections_forward_get().values() {
-    //     println!("forward_connection: {:?}", connection);
-    // }
+    // INFO: START: test setting connection twice
+    let temp_node_id = node.node_id.clone();
+    graph.nodes_connection_set(temp_node_id, 3, 6666).unwrap();
+
+    let node = graph.node_get(node_id).unwrap();
+    let forwards = node.connections_forward_get_all();
+    assert_eq!(forwards.data_vec.len(), 2);
+    let conn_forward3 = forwards.get(3).unwrap();
+    assert_eq!(conn_forward3.node_id, 3);
+    assert_eq!(conn_forward3.data, 6666);
+    // INFO: END: test setting connection twice
 
     let node2 = graph.node_get(2).unwrap();
-    let backwards = node2.connections_backward_get();
+    let backwards = node2.connections_backward_get_all();
     // println!("forwards: {:?}", forwards);
     assert_eq!(backwards.len(), 1);
     assert_eq!(backwards.get(&0).unwrap(), &0);
-
-    // for connection in node2.connections_backward_get() {
-    //     println!("backward_connection: {:?}", connection);
-    // }
 
     let node3 = graph.node_get(3).unwrap();
-    let backwards = node3.connections_backward_get();
+    let backwards = node3.connections_backward_get_all();
     // println!("forwards: {:?}", forwards);
     assert_eq!(backwards.len(), 1);
     assert_eq!(backwards.get(&0).unwrap(), &0);
 
-    // for connection in node3.connections_backward_get() {
-    //     println!("backward_connection: {:?}", connection);
-    // }
+    graph.nodes_connection_remove(0, 4).unwrap();
+    let node0 = graph.node_get(0).unwrap();
+    let forwards = node0.connections_forward_get_all();
+    // println!("forwards: {:?}", forwards);
+    assert_eq!(forwards.data_vec.len(), 2);
 
-    graph.nodes_connection_create(2, 0, 352).unwrap();
+    graph.nodes_connection_remove(0, 2).unwrap();
+    let node0 = graph.node_get(0).unwrap();
+    let forwards = node0.connections_forward_get_all();
+    // println!("forwards: {:?}", forwards);
+    assert_eq!(forwards.data_vec.len(), 1);
+
+    graph.nodes_connection_set(2, 0, 352).unwrap();
     let node2 = graph.node_get(2).unwrap();
-    let forwards = node2.connections_forward_get();
-    assert_eq!(forwards.len(), 1);
-    assert_eq!(forwards.get(&0).unwrap().data, 352);
+    let forwards = node2.connections_forward_get_all();
+    assert_eq!(forwards.data_vec.len(), 1);
+    assert_eq!(forwards.get(0).unwrap().data, 352);
 
-    graph.nodes_connection_delete(2, 0).unwrap();
+    graph.nodes_connection_remove(2, 0).unwrap();
     let node2 = graph.node_get(2).unwrap();
-    let forwards = node2.connections_forward_get();
-    assert_eq!(forwards.len(), 0);
+    let forwards = node2.connections_forward_get_all();
+    assert_eq!(forwards.data_vec.len(), 0);
 
+    graph.node_delete(4).unwrap();
     graph.node_delete(2).unwrap();
     assert_eq!(graph.num_entries, 3);
     assert_eq!(graph.nodes_vector.len(), 4);
@@ -111,15 +127,11 @@ fn test_basic_functions() {
     assert_eq!(graph.empty_slots[0], 2);
 
     let node = graph.node_get(node_id).unwrap();
-    let forwards = node.connections_forward_get();
+    let forwards = node.connections_forward_get_all();
     // println!("forwards: {:?}", forwards);
-    assert_eq!(forwards.len(), 1);
-    assert_eq!(forwards.get(&3).unwrap().node_id, 3);
-    assert_eq!(forwards.get(&3).unwrap().data, 24323);
-
-    // for connection in node.connections_forward_get().values() {
-    //     println!("forward_connection: {:?}", connection);
-    // }
+    assert_eq!(forwards.data_vec.len(), 1);
+    assert_eq!(forwards.get(3).unwrap().node_id, 3);
+    assert_eq!(forwards.get(3).unwrap().data, 6666);
 
     graph.node_delete(0).unwrap();
     assert_eq!(graph.num_entries, 2);
@@ -128,7 +140,7 @@ fn test_basic_functions() {
     assert_eq!(graph.empty_slots[1], 0);
 
     let node3 = graph.node_get(3).unwrap();
-    let backwards = node3.connections_backward_get();
+    let backwards = node3.connections_backward_get_all();
     // println!("forwards: {:?}", forwards);
     assert_eq!(backwards.len(), 0);
 
@@ -214,7 +226,7 @@ fn create_connections_test(
 
         for &second_node in random_nodes_to_connect {
             graph
-                .nodes_connection_create(entry_index, second_node, i as u32)
+                .nodes_connection_set(entry_index, second_node, i as u32)
                 .unwrap();
         }
 


### PR DESCRIPTION
Switched connections_forward from using a hashmap to using a vector hashmap combination. This makes it easier to split the connections_forward into separate slices for parallel processing.